### PR TITLE
Fix-jest-test-error 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   transform: {
     "^.+\\.(ts|tsx)$": "<rootDir>/preprocessor.js"
   },
+  testURL: "http://localhost",
   testMatch: ["**/tests/*.(ts|tsx|js|jsx)"],
   moduleDirectories: ["node_modules", "bower_components"]
 };


### PR DESCRIPTION
simple update to `jest.config` to prevent failing jest-tests due to recent issue with JSDom security errors.

## Error Before
<img width="670" alt="screen shot 2018-08-17 at 11 36 11 pm" src="https://user-images.githubusercontent.com/13424017/44295464-46f3f080-a277-11e8-8a7b-37ea5200f30c.png">

[Where I found Fix](https://github.com/apollographql/apollo-client/commit/8cb01d5bcf6be36e98b5470af416c60303c74ee7)