### PR TITLE
fix: Adding Windows support for scripty

### DIFF
--- a/scripts-win/build/dev.cmd
+++ b/scripts-win/build/dev.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+./node_modules/.bin/webpack --progress --profile --colors --env

--- a/scripts-win/build/dist.cmd
+++ b/scripts-win/build/dist.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+webpack --optimize-minimize --define process.env.NODE_ENV='production' --progress --profile --colors --env

--- a/scripts-win/clean.cmd
+++ b/scripts-win/clean.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+./node_modules/.bin/rimraf dist

--- a/scripts-win/test/ci.cmd
+++ b/scripts-win/test/ci.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+./node_modules/.bin/jest --no-cache -u
+git checkout exercises/**/*.tsx.snap

--- a/scripts-win/test/index.cmd
+++ b/scripts-win/test/index.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+./node_modules/.bin/jest --no-cache --watch %1


### PR DESCRIPTION
Quoting the scripty's documentations (https://www.npmjs.com/package/scripty)

"If your project needs to run scripts in both Windows & Unix, then you may define a scripts-win/ directory with a symmetrical set of scripts to whatever Unix scripts might be found in scripts/"

This fix is for the issue #110 