### PR TITLE
Adds lib to tsconfig file 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "strictFunctionTypes": true,
     "strictBindCallApply": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    "lib": ["es2015", "dom"]
   },
   "include": ["examples/*/src", "challenges/*/src", "notes"]
 }


### PR DESCRIPTION
modifies tsconfig to include es2015 and dom in the lib.

Previously, VSCode was throwing errors in the "hello-ts" index.js file and asked for these to be included - this change to "tsconfig.json" resolves the issues!