### PR TITLE
Solve the issue of building hello code. (npm run build )

### DIFF
--- a/examples/hello-ts/package.json
+++ b/examples/hello-ts/package.json
@@ -19,5 +19,8 @@
     "build": "tsc src/index.ts --outDir lib --types node --module commonjs --target ES2017",
     "test": "echo 'No tests'"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/node": "^13.7.0",
+    "typescript": "^3.7.5"
+  }
 }


### PR DESCRIPTION
Follow the course to do the following command
$ npm run build
There are failed information here. 

> hello-ts@0.0.0 build /Users/pebblarmbp/Desktop/TypeScript/typescript-fundamentals/examples/hello-ts
> tsc src/index.ts --outDir lib --types node --module commonjs --target ES2017
> 
> sh: tsc: command not found
> npm ERR! code ELIFECYCLE
> npm ERR! syscall spawn
> npm ERR! file sh
> npm ERR! errno ENOENT
> npm ERR! hello-ts@0.0.0 build: `tsc src/index.ts --outDir lib --types node --module commonjs --target ES2017`
> npm ERR! spawn ENOENT
> npm ERR! 
> npm ERR! Failed at the hello-ts@0.0.0 build script.
> npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
> npm WARN Local package.json exists, but node_modules missing, did you mean to install?
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /Users/pebblarmbp/.npm/_logs/2020-02-07T05_56_55_262Z-debug.log

The way to solve it is to install typescript package and @types/node package.